### PR TITLE
fixes to build process for zig 0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ The code is released under GPLv3, but if you wish to write your own proprietary 
     
 ## Compiling
 1. Make sure the Playdate SDK is installed, Zig is installed and in your PATH, and all other [requirements](#Requirements) are met.
-1. Run `zig build -Drelease-fast=true` which will compile the release version of the game.
+1. Run `zig build -Doptimize=ReleaseFast` which will compile the release version of the game.
     - If there any errors, double check `PLAYDATE_SDK_PATH` is correctly set and either binutils or the ARM Toolchain (depending on your OS) is properly installed and set in your `PATH`.
 1. The `upward.pdx` executable should be produced in the newly created `zig-out` folder.  
     - Keep in mind, this executable will only run on the platform you compiled on, plus Playdate hardware. If you want your `updward.pdx` to be "universal", you will need to compile this codebase on macOS, Windows, and Linux, and have an `upward.pdx` that contains `pdex.dylib`, `pdex.dll`, and `pdex.so`.   
 
 ## Running on the Playdate Simulator
 1. Make sure the Playdate Simulator is closed.
-1. Run `zig build -Drelease-fast=true run`.
+1. Run `zig build -Doptimize=ReleaseFast run`.
     - If there any errors, double check `PLAYDATE_SDK_PATH` is correctly set and either binutils or the ARM Toolchain (depending on your OS) is properly installed and set in your `PATH`.
 1. Optionally, connect your Playdate to the comupter and upload to the device by going to `Device` -> `Upload Game to Device..` in the Playdate Simulator.
 

--- a/build.zig
+++ b/build.zig
@@ -19,7 +19,7 @@ pub fn build(b: *std.build.Builder) !void {
     lib.addModule("toolbox", toolbox_module);
 
     const output_path = "Source";
-    const lib_step = b.addInstallArtifact(lib);
+    const lib_step = b.addInstallArtifact(lib, .{});
     lib_step.dest_dir = .{ .custom = output_path };
 
     const playdate_target = try std.zig.CrossTarget.parse(.{
@@ -40,7 +40,7 @@ pub fn build(b: *std.build.Builder) !void {
     game_elf.force_pic = true;
     game_elf.link_emit_relocs = true;
     game_elf.setLinkerScriptPath(.{ .path = "link_map.ld" });
-    const game_elf_step = b.addInstallArtifact(game_elf);
+    const game_elf_step = b.addInstallArtifact(game_elf, .{});
     game_elf_step.dest_dir = .{ .custom = output_path };
     if (optimize == .ReleaseFast) {
         game_elf.omit_frame_pointer = true;


### PR DESCRIPTION
I've done some C++ before but I am completely new to Zig.

I got it working on a playdate sim, but I had to make some changes for zig compiler 0.11.0 (as far as I can tell this is latest stable zig). Am I using the right version?
I got this version of zig from homebrew, maybe I am on an old version and these changes are actually regressions.

- `-Drelease-fast` option seems to have changed to `-Doptimize=ReleaseFast`. [The docs](https://ziglang.org/documentation/master/#Build-Mode) suggest the `-Doptimize` is the new way but not sure.
- `addInstallArtefact` seems to need an extra argument. However on the release notes in `0.11.0` [there is a snippet](https://ziglang.org/download/0.11.0/release-notes.html#Package-Management) (second code listing in section) that uses `addInstallArtefact` with no second argument so I think this is because I don't understand something about zig. I've included the error I get below.


```
error: member function expected 2 argument(s), found 1
    const lib_step = b.addInstallArtifact(lib);
                     ~^~~~~~~~~~~~~~~~~~~
/opt/homebrew/Cellar/zig/0.11.0/lib/zig/std/Build.zig:1292:5: note: function declared here
pub fn addInstallArtifact(
~~~~^~
```
